### PR TITLE
Default EC2 EBS from 500 GB to 20 GB.

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -300,12 +300,6 @@ Resources:
       InstanceType: !Ref NodeInstanceType
       SecurityGroups:
       - !Ref NodeSecurityGroup
-      BlockDeviceMappings:
-      - DeviceName: /dev/xvda
-        Ebs:
-          VolumeSize: !Ref NodeVolumeSize
-          VolumeType: gp2
-          DeleteOnTermination: true
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash


### PR DESCRIPTION
This will reduce costs from $50/month/node to $2/month/node.
However, the current nodes will need to be respawned manually when no one is using them.