### PR TITLE
Add GPU option. Make Core node. Fix crons. (#66)

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -50,30 +50,52 @@ Parameters:
     Description: Tag of ECR docker image.
     Type: String
 
-  NodeImageId:
+  NodeImageIdGPU:
+    Description: AMI id for the node instances of K8s
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2-gpu/recommended/image_id
+
+  NodeImageIdCPU:
     Description: AMI id for the node instances of K8s
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2/recommended/image_id
 
-  NodeInstanceType:
-    Description: EC2 instance type for the node instances.
+  NodeImageIdCore:
+    Description: AMI id for the node instances of K8s
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2/recommended/image_id
+
+  NodeInstanceTypeCore:
+    Description: EC2 instance type for the node Core instances.
+    Type: String
+    Default: t3a.medium
+
+  NodeInstanceTypeGPU:
+    Description: EC2 instance type for the node GPU instances.
+    Type: String
+    Default: g4dn.2xlarge
+
+  NodeInstanceTypeCPU:
+    Description: EC2 instance type for the node CPU instances.
     Type: String
     Default: m5.2xlarge
 
-  NodeAutoScalingGroupMinSize:
+  NodeAutoScalingGroupMinSizeCPU:
     Description: Minimum size of Node Group ASG.
     Type: Number
     Default: 2
 
-  NodeAutoScalingGroupMaxSize:
-    Description: Maximum size of Node Group ASG. Set to at least 1 greater than NodeAutoScalingGroupDesiredCapacity.
+  NodeAutoScalingGroupMaxSizeCPU:
+    Description: Maximum size of Node Group ASG. Set to at least 1 greater than NodeAutoScalingGroupDesiredCapacityCPU.
     Type: Number
     Default: 8
 
-  NodeAutoScalingGroupDesiredCapacity:
+  NodeAutoScalingGroupDesiredCapacityCPU:
     Description: Desired capacity of Node Group ASG.
     Type: Number
     Default: 2
+
+
 
   NodeVolumeSize:
     Description: Node volume size (GB)
@@ -264,13 +286,13 @@ Resources:
       ToPort: 443
       FromPort: 443
 
-  AutoScalingGroup:
+  AutoScalingGroupCore:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      DesiredCapacity: !Ref NodeAutoScalingGroupDesiredCapacity
-      LaunchConfigurationName: !Ref LaunchConfiguration
-      MinSize: !Ref NodeAutoScalingGroupMinSize
-      MaxSize: !Ref NodeAutoScalingGroupMaxSize
+      DesiredCapacity: 1
+      LaunchConfigurationName: !Ref LaunchConfigurationCore
+      MinSize: 1
+      MaxSize: 2
       VPCZoneIdentifier: !Ref ActiveSubnets
       TargetGroupARNs:
       - !Ref TargetGroup
@@ -291,20 +313,112 @@ Resources:
         Value: true
         PropagateAtLaunch: true
 
-  LaunchConfiguration:
+  LaunchConfigurationCore:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       AssociatePublicIpAddress: true
       IamInstanceProfile: !Ref NodeInstanceProfile
-      ImageId: !Ref NodeImageId
-      InstanceType: !Ref NodeInstanceType
+      ImageId: !Ref NodeImageIdCore
+      InstanceType: !Ref NodeInstanceTypeCore
       SecurityGroups:
       - !Ref NodeSecurityGroup
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
           set -o xtrace
-          /etc/eks/bootstrap.sh ${Cluster}
+          /etc/eks/bootstrap.sh ${Cluster} --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=core,server_type=core'
+          /opt/aws/bin/cfn-signal --exit-code $? \
+          --stack  ${AWS::StackName} \
+          --resource NodeGroup  \
+          --region ${AWS::Region}
+
+  AutoScalingGroupGPU:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      DesiredCapacity: 0
+      LaunchConfigurationName: !Ref LaunchConfigurationGPU
+      MinSize: 0
+      MaxSize: 5
+      VPCZoneIdentifier: !Ref ActiveSubnets
+      TargetGroupARNs:
+      - !Ref TargetGroup
+      Tags:
+      - Key: Name
+        Value: !Sub ${AWS::StackName}-instance
+        PropagateAtLaunch: true
+      - Key: !Sub k8s.io/cluster/${Cluster}
+        Value: owned
+        PropagateAtLaunch: true
+      - Key: !Sub kubernetes.io/cluster/${Cluster}
+        Value: owned
+        PropagateAtLaunch: true
+      - Key: k8s.io/cluster-autoscaler/enabled
+        Value: true
+        PropagateAtLaunch: true
+      - Key: !Sub k8s.io/cluster-autoscaler/${Cluster}
+        Value: true
+        PropagateAtLaunch: true
+
+  LaunchConfigurationGPU:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref NodeInstanceProfile
+      ImageId: !Ref NodeImageIdGPU
+      InstanceType: !Ref NodeInstanceTypeGPU
+      SecurityGroups:
+      - !Ref NodeSecurityGroup
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -o xtrace
+          /etc/eks/bootstrap.sh ${Cluster} --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=user,k8s.amazonaws.com/accelerator=nvidia-tesla-k80,server_type=general_gpu'
+          /opt/aws/bin/cfn-signal --exit-code $? \
+          --stack  ${AWS::StackName} \
+          --resource NodeGroup  \
+          --region ${AWS::Region}
+
+  AutoScalingGroupCPU:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      DesiredCapacity: !Ref NodeAutoScalingGroupDesiredCapacityCPU
+      LaunchConfigurationName: !Ref LaunchConfigurationCPU
+      MinSize: !Ref NodeAutoScalingGroupMinSizeCPU
+      MaxSize: !Ref NodeAutoScalingGroupMaxSizeCPU
+      VPCZoneIdentifier: !Ref ActiveSubnets
+      TargetGroupARNs:
+      - !Ref TargetGroup
+      Tags:
+      - Key: Name
+        Value: !Sub ${AWS::StackName}-instance
+        PropagateAtLaunch: true
+      - Key: !Sub k8s.io/cluster/${Cluster}
+        Value: owned
+        PropagateAtLaunch: true
+      - Key: !Sub kubernetes.io/cluster/${Cluster}
+        Value: owned
+        PropagateAtLaunch: true
+      - Key: k8s.io/cluster-autoscaler/enabled
+        Value: true
+        PropagateAtLaunch: true
+      - Key: !Sub k8s.io/cluster-autoscaler/${Cluster}
+        Value: true
+        PropagateAtLaunch: true
+
+  LaunchConfigurationCPU:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      AssociatePublicIpAddress: true
+      IamInstanceProfile: !Ref NodeInstanceProfile
+      ImageId: !Ref NodeImageIdCPU
+      InstanceType: !Ref NodeInstanceTypeCPU
+      SecurityGroups:
+      - !Ref NodeSecurityGroup
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -o xtrace
+          /etc/eks/bootstrap.sh ${Cluster} --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=user,server_type=general_cpu'
           /opt/aws/bin/cfn-signal --exit-code $? \
           --stack  ${AWS::StackName} \
           --resource NodeGroup  \
@@ -449,7 +563,8 @@ Resources:
                 - helm upgrade jupyter jupyterhub/jupyterhub --install --namespace jupyter  --version 0.9.0-beta.4  --values helm_config.yaml --timeout=1800
                     --set auth.admin.users[0]=${AdminUserName}
                     --set proxy.secretToken=$(openssl rand -hex 32),proxy.service.nodePorts.http='${NodeProxyPort}'
-                    --set singleuser.extraEnv.AWS_ACCESS_KEY_ID='${NodeAccessKeyId}',singleuser.extraEnv.AWS_SECRET_ACCESS_KEY='${NodeSecretKey}',singleuser.image.name='${ImageName}',singleuser.image.tag='${ImageTag}'
+                    --set singleuser.extraEnv.AWS_ACCESS_KEY_ID='${NodeAccessKeyId}',singleuser.extraEnv.AWS_SECRET_ACCESS_KEY='${NodeSecretKey}'
+                    --set custom.IMAGE_NAME='${ImageName}',custom.IMAGE_TAG='${ImageTag}'
                     --set custom.OAUTH_CLIENT_ID='${OAuthClientId}',custom.OAUTH_CLIENT_SECRET='${OAuthClientSecret}'
                     --set custom.OAUTH_JUPYTER_URL=$( [ -n '${JupyterHubURL}' ] && echo '${JupyterHubURL}' || echo 'https://${LoadBalancer.DNSName}' )
                     --set custom.OAUTH_DNS_NAME='${OAuthDnsName}'
@@ -460,11 +575,12 @@ Resources:
                 - kubectl -n jupyter rollout status -w deployment.apps/hub
                 - kubectl --logtostderr=true -n jupyter patch deployment hub -p '{"spec":{"template":{"spec":{"containers":[{"name":"hub","command":["sh","-c","sudo /usr/sbin/service cron start && jupyterhub --config /etc/jupyterhub/jupyterhub_config.py --upgrade-db"],"securityContext":{"allowPrivilegeEscalation":"true"}}]}}}}' || true
                 - kubectl create clusterrolebinding cluster-pv --clusterrole=system:persistent-volume-provisioner --serviceaccount=jupyter:hub --dry-run -o yaml | kubectl apply -f -
+                - kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/aws-k8s-cni.yaml
                 - helm repo update
                 - helm fetch stable/cluster-autoscaler
                 - tar -zxf cluster-autoscaler*
                 - helm upgrade autoscaler stable/cluster-autoscaler --install --namespace autoscaler --values cluster-autoscaler*/values.yaml --timeout=120
-                    --set autoDiscovery.clusterName=${Cluster},awsRegion=${AWS::Region},sslCertPath='/etc/kubernetes/pki/ca.crt',rbac.create=True
+                    --set autoDiscovery.clusterName=${Cluster},awsRegion=${AWS::Region},sslCertPath='/etc/kubernetes/pki/ca.crt',rbac.create=True,nodeSelector."hub\\.jupyter\\.org/node-purpose"=core
                 - curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml | sed "s/{{cluster_name}}/${Cluster}/;s/{{region_name}}/${AWS::Region}/" | kubectl apply -f -
       LogsConfig:
         CloudWatchLogs:

--- a/helm_config.yaml
+++ b/helm_config.yaml
@@ -31,9 +31,6 @@ singleuser:
   extraEnv:
     AWS_ACCESS_KEY_ID: NODE_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: NODE_SECRET_KEY
-  image:
-    name: IMAGE_NAME
-    tag: IMAGE_TAG
   storage:
     capacity: 500Gi
   memory:
@@ -47,6 +44,10 @@ hub:
       tag: HUB_IMAGE_TAG
 
     extraConfig:
+        myAdminAccess.py: |
+            print("Admin user access not implemented...")
+            # c.JupyterHub.admin_access = True
+
         myAuthConfig.py: |
             try:
                 import sys
@@ -102,7 +103,7 @@ hub:
                     }
 
                     try:
-                        meta['vol_size'] = int(z2jh.get_config('VOLUME_SIZE'))
+                        meta['vol_size'] = int(z2jh.get_config('custom.VOLUME_SIZE'))
                     except:
                         meta['vol_size'] = 500
 
@@ -175,21 +176,21 @@ hub:
                     kubernetes_service_port=os.environ['KUBERNETES_SERVICE_PORT'],
                     kubernetes_service_host=os.environ['KUBERNETES_SERVICE_HOST']
                 )
-                with open("/srv/etc/meta.yaml", mode='w') as f:
+                with open("/etc/jupyterhub/custom/meta.yaml", mode='w') as f:
                     f.write(meta)
 
                 # Make file executable
-                os.chmod('/srv/etc/meta.yaml', 0o755)
+                os.chmod('/etc/jupyterhub/custom/meta.yaml', 0o755)
 
                 # Setup crontab for volume killer
                 cron = CronTab(user='jovyan')
 
-                job1 = cron.new(command='python3 /srv/etc/delete_volumes.py > /srv/etc/delete_volumes.log')
+                job1 = cron.new(command='python3 /etc/jupyterhub/custom/delete_volumes.py > /etc/jupyterhub/custom/delete_volumes.log')
                 job1.hour.on(12)  # 12 UTC, 3am AKDT
                 job1.enable()
 
                 # Setup crontab for snapshot killer
-                job2 = cron.new(command='python3 /srv/etc/delete_snapshot.py > /srv/etc/delete_snapshot.log')
+                job2 = cron.new(command='python3 /etc/jupyterhub/custom/delete_snapshot.py > /etc/jupyterhub/custom/delete_snapshot.log')
                 job2.hour.on(13)  # 13 UTC, 4am AKDT
                 job2.enable()
 
@@ -197,6 +198,54 @@ hub:
 
             except Exception as e:
                 print(e)
+
+        myProfiles.py: |
+
+            import z2jh
+
+            # Profile list programmatically
+            # Ideally, if/else statements based on permissions would determine the final choices.
+            # https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner
+            # Other singleuser server params can be taken from above to below as needed.
+
+            group = ('general_cpu')  #, 'general_gpu')
+
+            c.KubeSpawner.profile_list = []
+
+            if 'general_cpu' in group:
+                profile = {
+                    'display_name': 'General SAR processing',
+                    'description': 'Contains basic SAR processing and analysis tools',
+                    'default': True,
+                    'kubespawner_override': {
+                        'extra_labels': {
+                            'server_type': 'general_cpu'
+                        },
+                        'node_selector': {
+                            'server_type': 'general_cpu'
+                        },
+                        'image': "{0}:{1}".format(z2jh.get_config('custom.IMAGE_NAME'), z2jh.get_config('custom.IMAGE_TAG'))
+                    }
+                }
+                c.KubeSpawner.profile_list.append(profile)
+
+            if 'general_gpu' in group:
+                profile = {
+                    'display_name': 'General SAR processing including GPU support',
+                    'description': 'Contains basic SAR processing and analysis tools',
+                    'default': False,
+                    'kubespawner_override': {
+                        'extra_labels': {
+                            'server_type': 'general_gpu'
+                        },
+                        'node_selector': {
+                            'server_type': 'general_gpu'
+                        },
+                        'image': "{0}:{1}".format(z2jh.get_config('custom.IMAGE_NAME'), z2jh.get_config('custom.IMAGE_TAG'))
+                    }
+                }
+                c.KubeSpawner.profile_list.append(profile)
+
 
         mySubdomainConfig.py: |
             print("Subdomain not implemented...")
@@ -215,6 +264,8 @@ custom:
   CLUSTER_NAME: CLUSTER_NAME
   AZ_NAME: AZ_NAME
   VOLUME_SIZE: VOLUME_SIZE
+  IMAGE_NAME: IMAGE_NAME
+  IMAGE_TAG: IMAGE_TAG
 
 cull:
   enabled: true
@@ -225,13 +276,9 @@ scheduling:
   userScheduler:
     enabled: true
     replicas: 1
-  #podPriority:
-    #enabled: true
-  #userPlaceholder:
-    #replicas: 1
-    #globalDefault: true
-    #defaultPriority: 10
-    #userPlaceholderPriority: 0
-  #userPods:
-    #nodeAffinity:
-      #matchNodePurpose: require  # hub.jupyter.org/node-purpose=user
+  corePods:
+    nodeAffinity:
+      matchNodePurpose: require  # hub.jupyter.org/node-purpose=core
+  userPods:
+    nodeAffinity:
+      matchNodePurpose: require  # hub.jupyter.org/node-purpose=user

--- a/hub/dockerfile
+++ b/hub/dockerfile
@@ -25,15 +25,15 @@ COPY generic_with_logout.py /usr/local/lib/python3.6/dist-packages/generic_with_
 COPY login.html /usr/local/share/jupyterhub/templates/login.html
 COPY pending.html /usr/local/share/jupyterhub/templates/pending.html
 
-COPY pv.yaml /srv/etc/pv.yaml
-COPY pvc.yaml /srv/etc/pvc.yaml
-COPY volume_stopping_tags.py /srv/etc/volume_stopping_tags.py
-COPY volume_from_snapshot.py /srv/etc/volume_from_snapshot.py
-COPY delete_volumes.py /srv/etc/delete_volumes.py
-COPY delete_snapshot.py /srv/etc/delete_snapshot.py
-
-RUN chown -R 1000:0 /srv/etc/
-ENV PYTHONPATH "${PYTHONPATH}:/srv/etc/"
+RUN mkdir -p /etc/jupyterhub/custom
+COPY pv.yaml /etc/jupyterhub/custom/pv.yaml
+COPY pvc.yaml /etc/jupyterhub/custom/pvc.yaml
+COPY volume_stopping_tags.py /etc/jupyterhub/custom/volume_stopping_tags.py
+COPY volume_from_snapshot.py /etc/jupyterhub/custom/volume_from_snapshot.py
+COPY delete_volumes.py /etc/jupyterhub/custom/delete_volumes.py
+COPY delete_snapshot.py /etc/jupyterhub/custom/delete_snapshot.py
+RUN chown -R 1000:0 /etc/jupyterhub/custom/
+ENV PYTHONPATH "${PYTHONPATH}:/etc/jupyterhub/custom/"
 
 RUN echo 'jovyan  ALL=NOPASSWD: /usr/sbin/service cron start' >> /etc/sudoers
 


### PR DESCRIPTION
* Add ASGs for GPU, core. Core hub is seperate.

* Move CF labelling to bootstap

* Proper --node-labels

* Increase hub instance size

* Make core instance the same as user.
To make sure we don't have a node image space issue

* extra_labels is a dict not list

* EC2hasGPU: "true" in quotes

* Explicit `EC2hasGPU=false`

* Try different labels.
To be more exclusive and maybe match better,

* kubespawner_override node_selector.instance_type

* Auto AMI gpu id

* Revert "Auto AMI gpu id"

This reverts commit 856a88861e35b21fd107710b6440f0cc0977273d.

* Auto AMI gpu id but a different way

* Explicit CNI update

* Smaller core instance

* Smaller hub instance

* Try to put autoscaler on core node

* Correct hub path in hub image

* Don't forget the mkdir

* Switch custom perms

* admin_access = True

* t3.micro and disable gpu profile

* Add GPU profile back

* t3a.medium

* Disable GPU profile again. Change CPU wording. Disable Admin user access

* Programatic profiles. Better named node labels

* Missing '

* f-strings so nothing is forgotten

* Better dict handling

* f-strings don't work. Use format

* helm upgrade set image/tag

* Seperate sub-config. Disbale GPU profile

* Get rid of duplicate profile code