### PR TITLE
Move git puller into profiler

### DIFF
--- a/helm_config.yaml
+++ b/helm_config.yaml
@@ -255,10 +255,10 @@ hub:
                             }
                         }
                         profile_list.append(profile)
-
-<<<<<<< HEAD
+                        
                     if 'no_smart_git' not in group_list:
-                        # Run gitpuller after mounting volume
+                        print("Run gitpuller after mounting volume")
+
                         spawner.lifecycle_hooks = {
                             "postStart": {
                                 "exec": {
@@ -267,8 +267,6 @@ hub:
                             }
                         }
 
-=======
->>>>>>> a084ed77886669515869a116680c767537e8b071
                     # This clause for sudo should always be last
                     if 'sudo' in group_list:
                         print("Adding sudo privs...")


### PR DESCRIPTION
Users can be added to the `no_smart_git` group. This will disable the use of the `git puller`. This is useful when git conflicts cause the git puller to fail and thus crash the user's notebook server.