### PR TITLE
Make no-smart-git-puller it's own profile

### DIFF
--- a/helm_config.yaml
+++ b/helm_config.yaml
@@ -238,7 +238,14 @@ hub:
                                 'node_selector': {
                                     'server_type': 'general_cpu'
                                 },
-                                'image': "{0}:{1}".format(z2jh.get_config('custom.IMAGE_NAME'), z2jh.get_config('custom.IMAGE_TAG'))
+                                'image': "{0}:{1}".format(z2jh.get_config('custom.IMAGE_NAME'), z2jh.get_config('custom.IMAGE_TAG')), 
+                                'lifecycle_hooks': {
+                                    "postStart": {
+                                        "exec": {
+                                            "command": ["/bin/sh", "-c", "gitpuller https://github.com/asfadmin/asf-jupyter-notebooks.git master /home/jovyan/notebooks;"]
+                                        }
+                                    }
+                                }
                             }
                         }
                         profile_list.append(profile)
@@ -260,18 +267,24 @@ hub:
                         }
                         profile_list.append(profile)
                         
-                    if 'no_smart_git' not in group_list:
-                        print("Run gitpuller after mounting volume")
+                    if 'no_smart_git' in group_list:
+                        print("Do not run gitpuller after on general_cpu")
 
-                        spawner.lifecycle_hooks = {
-                            "postStart": {
-                                "exec": {
-                                    "command": ["/bin/sh", "-c", "gitpuller https://github.com/asfadmin/asf-jupyter-notebooks.git master /home/jovyan/notebooks;"]
-                                }
+                        profile = {
+                            'display_name': 'General SAR processing (without git puller)',
+                            'description': 'Useful for debugging some server timeouts. Contains basic SAR processing and analysis tools. This does not pull in the latest notebooks.',
+                            'default': False,
+                            'kubespawner_override': {
+                                'extra_labels': {
+                                    'server_type': 'general_cpu'
+                                },
+                                'node_selector': {
+                                    'server_type': 'general_cpu'
+                                },
+                                'image': "{0}:{1}".format(z2jh.get_config('custom.IMAGE_NAME'), z2jh.get_config('custom.IMAGE_TAG'))
                             }
                         }
-                    else:
-                        print("Not running gitpuller after mounting volume.")
+                        profile_list.append(profile)
 
                     # This clause for sudo should always be last
                     if 'sudo' in group_list:

--- a/hub/login/login.html
+++ b/hub/login/login.html
@@ -13,6 +13,10 @@
 {% if login_service %}
     <div class="service-login">
       <div class="announcement">
+        <p style="color: black; font-size: 14pt;">
+            Users have reported server timeouts. 
+            If this happens, please email the <a href="mailto:uaf-jupyterhub-asf@alaska.edu">OpenSARlab Admin</a> with time and description of the event.
+        </p>
       </div>
       <div class="main-center">
         <img style="float: left; max-height: 37px; margin-top: 7px; margin-left: 5px; z-index: 10;" src="{{static_url('images/alaska_satellite_facility_1000.png')}}">
@@ -38,11 +42,11 @@
         }
 
         .announcement {
-            padding: 10pt 10pt 10pt 10pt;
-            border: 3px solid #ff0000;
+            padding: 15pt 10pt 10pt 10pt;
+            border: 3px solid #efff00;
             margin: 70px 0px;
             color: black;
-            visibility: hidden;
+            /*visibility: hidden;*/
         }
 
         .main-center {

--- a/hub/volumes/delete_snapshot.py
+++ b/hub/volumes/delete_snapshot.py
@@ -34,10 +34,14 @@ class DeleteSnapshot():
         self.days_since_activity_thresholds = [30,44,46]
 
         print(f"Dry run set to {dry_run}")
-        if dry_run: 
-            self.dry_run_disable = dry_run
-            self.dry_run_delete = dry_run 
-            self.dry_run_email = dry_run
+        if dry_run == True: 
+            self.dry_run_disable = True
+            self.dry_run_delete = True 
+            self.dry_run_email = True
+        else:
+            self.dry_run_disable = False
+            self.dry_run_delete = False 
+            self.dry_run_email = False
 
         self.cognito = session.client('cognito-idp')
         user_pools = self.cognito.list_user_pools(MaxResults=10)


### PR DESCRIPTION
This is so it's easier to overcome git issues with the notebooks. A blurb explaining to email ASF if there is a server timeout is added to the login page.

For some reason, the dry-run variable in delete_snapshots.py errors out in prod but not in test. So I updated that to hopefully fix that.