### PR TITLE
Separate IAM perms by file

### DIFF
--- a/scripts/service_account_policy.json
+++ b/scripts/service_account_policy.json
@@ -2,26 +2,67 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "SAHub",
+            "Sid": "SAHubDeleteVolumes",
             "Effect": "Allow",
             "Action": [
-                "iam:GetRole",
-                "iam:GetPolicy",
-                "iam:PutRolePolicy",
-                "ec2:CreateTags",
-                "ec2:CreateVolume",
                 "ec2:DescribeSnapshots",
-                "ec2:DeleteVolume",
+                "ec2:DescribeVolumes"
+            ],
+            "Resource": "*"
+        }, 
+        {
+            "Sid": "SAHubDeleteSnapshots",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSnapshots",
+                "ec2:DeleteSnapshot",
                 "ec2:DescribeVolumes",
                 "cognito-idp:ListUserPools",
                 "cognito-idp:AdminGetUser",
-                "cognito-idp:ListUserPoolClients",
                 "cognito-idp:AdminDisableUser",
-                "cognito-idp:DescribeUserPoolClient",
                 "cognito-idp:ListUsers",
-                "ses:SendEmail",
-                "eks:DescribeCluster",
-                "sts:GetCallerIdentity"
+                "ses:SendEmail"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "SAHubForceDeactivation",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSnapshots",
+                "ec2:DeleteSnapshot",
+                "cognito-idp:ListUserPools",
+                "cognito-idp:ListUsers",
+                "cognito-idp:AdminDisableUser"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "SAHubVolumeFromSnapshot",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSnapshots",
+                "ec2:CreateVolume", 
+                "ec2:CreateTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "SAHubVolumeStoppingTags",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeVolumes", 
+                "ec2:CreateTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "SAHubGenericWithLogout",
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:ListUserPools",
+                "cognito-idp:ListUserPoolClients", 
+                "cognito-idp:DescribeUserPoolClient"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
For cleaner management.

For now, these policies will need to be attached to `opensarlab-instance` so that the volume and snapshot reapers work properly. Eventually, the RBAC will be fixed.