### PR TITLE
Add backup instance handling

### DIFF
--- a/opensarlab/opensarlab.example.yaml
+++ b/opensarlab/opensarlab.example.yaml
@@ -27,7 +27,7 @@ nodes:
     is_hub: True  # Required
 
   - name: Name of node type. Must be alphanumeric (no special characters, whitespace, etc.)
-    instance: The EC2 instance for the hub node (m5a.2xlarge)
+    instance: Comma seperated list of EC2 instances for the node, lowest price has precedence (m5a.2xlarge)
     min_number: Minimum number of running node of this type in the cluster (0)
     max_number: Maximum number of running node of this type in the cluster (25)
     node_policy: Node permission policy (user)

--- a/opensarlab/pipeline/templates/cf-cluster.yaml.jinja
+++ b/opensarlab/pipeline/templates/cf-cluster.yaml.jinja
@@ -31,17 +31,17 @@ Parameters:
   VpcId:
     Description: The VPC of the worker instances
     Type: AWS::EC2::VPC::Id
-    Default: {{ parameters.vpc_id }}
+    Default: {{ parameters.vpc_id or "NEED_PIPELINE_VALUE" }}
 
   Subnets:
     Description: The subnets where workers can be created.
     Type: List<AWS::EC2::Subnet::Id>
-    Default: {{ parameters.all_subnets }}
+    Default: {{ parameters.all_subnets or "NEED_PIPELINE_VALUE" }}
 
   ActiveSubnets:
     Description: The subnets actually used by resources in the cluster. Typically only one (e.g., subnet for AZ -d).
     Type: List<AWS::EC2::Subnet::Id>
-    Default: {{ parameters.active_subnets }}
+    Default: {{ parameters.active_subnets or "NEED_PIPELINE_VALUE" }}
 
   # The following values require defaults.
   LoadBalancerCidrBlock:
@@ -359,6 +359,7 @@ Resources:
 
   {% for node in nodes -%}
   {%- set node_name_escaped = node.name | regex_replace ("[^A-Za-z0-9]","00") -%}
+  {%- set node_instance = node.instance.replace(' ', '').split(',') -%}
 
   {% if node.is_hub is defined -%}
   Repository{{ node_name_escaped }}:
@@ -400,7 +401,17 @@ Resources:
   AutoScalingGroup{{ node_name_escaped }}:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      LaunchConfigurationName: !Ref LaunchConfiguration{{ node_name_escaped }}
+      MixedInstancesPolicy:
+        InstancesDistribution:
+          OnDemandAllocationStrategy: lowest-price
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            LaunchTemplateId: !Ref LaunchTemplate{{ node_name_escaped }}
+            Version: !GetAtt  LaunchTemplate{{ node_name_escaped }}.LatestVersionNumber
+          Overrides:
+            {%- for instance in node_instance %}
+            - InstanceType: {{ instance }}
+            {%- endfor %}
       MinSize: "{{ node.min_number}}"
       MaxSize: "{{ node.max_number}}"
       VPCZoneIdentifier: !Ref ActiveSubnets
@@ -428,35 +439,43 @@ Resources:
           Value: !Sub ${CostTagValue}
           PropagateAtLaunch: true
 
-  LaunchConfiguration{{ node_name_escaped }}:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  LaunchTemplate{{ node_name_escaped }}:
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      AssociatePublicIpAddress: true
-      {% if node.root_volume_size is defined -%}
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeType: gp2
-            VolumeSize: {{ node.root_volume_size }}
-            DeleteOnTermination: 'true'
-            Encrypted: 'false'
-      {% endif -%}
-      IamInstanceProfile: !Ref NodeInstanceProfile{{ node_name_escaped }}
-      ImageId: !Ref NodeImageId
-      InstanceType: {{ node.instance }}
-      SecurityGroups:
-        - !Ref NodeSecurityGroup
-      UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash
-          set -o xtrace
-          {% if node.is_hub is defined -%}
-          /etc/eks/bootstrap.sh ${CostTagValue}-cluster --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=core,server_type=core'
-          {% else -%}
-          /etc/eks/bootstrap.sh ${CostTagValue}-cluster --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=user,server_type={{ node_name_escaped }}'
-          {% endif -%}
-          AWS_INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
-          ROOT_VOLUME_IDS=$(aws ec2 describe-instances --region ${AWS::Region} --instance-id $AWS_INSTANCE_ID --output text --query Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId)
-          aws ec2 create-tags --resources $ROOT_VOLUME_IDS --region ${AWS::Region} --tags Key=${CostTagKey},Value=${CostTagValue} Key=Name,Value=${CostTagValue}-{{ node_name_escaped }}-root
-          /opt/aws/bin/cfn-signal --exit-code $? --stack ${AWS::StackName} --resource NodeGroup --region ${AWS::Region}
+      LaunchTemplateName: !Sub ${CostTagValue}-{{ node_name_escaped }}-launch-template
+      LaunchTemplateData:
+#        AssociatePublicIpAddress: true
+        {% if node.root_volume_size is defined -%}
+        BlockDeviceMappings:
+            - DeviceName: /dev/xvda
+              Ebs:
+                VolumeType: gp2
+                VolumeSize: {{ node.root_volume_size }}
+                DeleteOnTermination: 'true'
+                Encrypted: 'false'
+        {% endif -%}
+        IamInstanceProfile:
+          Name: !Ref NodeInstanceProfile{{ node_name_escaped }}
+        ImageId: !Ref NodeImageId
+        InstanceType: {{ node_instance[0] }}
+        SecurityGroupIds:
+          - !GetAtt NodeSecurityGroup.GroupId
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash
+            set -o xtrace
+            {% if node.is_hub is defined -%}
+            /etc/eks/bootstrap.sh ${CostTagValue}-cluster --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=core,server_type=core'
+            {% else -%}
+            /etc/eks/bootstrap.sh ${CostTagValue}-cluster --kubelet-extra-args '--node-labels=hub.jupyter.org/node-purpose=user,server_type={{ node_name_escaped }}'
+            {% endif -%}
+            AWS_INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+            ROOT_VOLUME_IDS=$(aws ec2 describe-instances --region ${AWS::Region} --instance-id $AWS_INSTANCE_ID --output text --query Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId)
+            aws ec2 create-tags --resources $ROOT_VOLUME_IDS --region ${AWS::Region} --tags Key=${CostTagKey},Value=${CostTagValue} Key=Name,Value=${CostTagValue}-{{ node_name_escaped }}-root
+            /opt/aws/bin/cfn-signal --exit-code $? --stack ${AWS::StackName} --resource NodeGroup --region ${AWS::Region}
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: !Sub ${CostTagKey}
+                Value: !Sub ${CostTagValue}
   {%- endfor %}


### PR DESCRIPTION
Update cluster code with ability to have automatic backup instances.

When AWS runs out of a certain instance type in a region, it normally will complain and throw an error. This leads to a unusable cluster. To alleviate this possible problem, deployers can now add a comma separated list of instance types to the `opensarlab.yaml` config for each node. When the first in the list reaches out-of-capacity, the next lowest price instance in the list will automatically be used.

Note that making sure the account/region have a high enough vCPU limit is not included.